### PR TITLE
Install C build toolchain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,11 @@ WORKDIR /grasp
 ENV PYTHONUNBUFFERED=1 \
   GRASP_INDEX_DIR=/opt/grasp
 
+# Install C build toolchain (required for search-rdf Rust/maturin compilation)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+  && rm -rf /var/lib/apt/lists/*
+
 # Copy files
 COPY . .
 


### PR DESCRIPTION
I ran into this issue when building, so I added `build-essential` and it fixed the issue and completed the build.  Perhaps it needed an ARM build for search-rdf.

> 293.9   Building wheel for search-rdf (pyproject.toml): started
> 294.9   Building wheel for search-rdf (pyproject.toml): finished with status 'error'
> 294.9   error: subprocess-exited-with-error
> 294.9   
> 294.9   × Building wheel for search-rdf (pyproject.toml) did not run successfully.
> 294.9   │ exit code: 1
> 294.9   ╰─> [61 lines of output]
> 294.9       Rust not found, installing into a temporary directory
> 294.9       Python reports SOABI: cpython-312-aarch64-linux-gnu
> 294.9       Computed rustc target triple: aarch64-unknown-linux-gnu
> 294.9       Installation directory: /root/.cache/puccinialin
> 294.9       Rustup already downloaded
> 294.9       Installing rust to /root/.cache/puccinialin/rustup
> 294.9       warn: It looks like you have an existing rustup settings file at:
> 294.9       warn: /root/.cache/puccinialin/rustup/settings.toml
> 294.9       warn: Rustup will install the default toolchain as specified in the settings file,
> 294.9       warn: instead of the one inferred from the default host triple.
> 294.9       info: profile set to minimal
> 294.9       info: setting default host triple to aarch64-unknown-linux-gnu
> 294.9       warn: Updating existing toolchain, profile choice will be ignored
> 294.9       info: syncing channel updates for stable-aarch64-unknown-linux-gnu
> 294.9       info: default toolchain set to stable-aarch64-unknown-linux-gnu
> 294.9       warn: no default linker (`cc`) was found in your PATH
> 294.9       warn: many Rust crates require a system C toolchain to build
> 294.9       Checking if cargo is installed
> 294.9       cargo 1.96.0 (30a34c682 2026-05-25)
> 294.9       Running `maturin pep517 build-wheel -i /usr/local/bin/python3.12 --compatibility off`
> 294.9       🍹 Building a mixed python/rust project
> 294.9       🐍 Found CPython 3.12 at /usr/local/bin/python3.12
> 294.9       🔗 Found pyo3 bindings with abi3 support
> 294.9          Compiling proc-macro2 v1.0.106
> 294.9          Compiling quote v1.0.45
> 294.9          Compiling unicode-ident v1.0.24
> 294.9          Compiling libc v0.2.183
> 294.9          Compiling cfg-if v1.0.4
> 294.9          Compiling serde_core v1.0.228
> 294.9          Compiling autocfg v1.5.0
> 294.9          Compiling memchr v2.8.0
> 294.9          Compiling find-msvc-tools v0.1.9
> 294.9          Compiling shlex v1.3.0
> 294.9          Compiling libm v0.2.16
> 294.9          Compiling stable_deref_trait v1.2.1
> 294.9          Compiling itoa v1.0.18
> 294.9          Compiling serde v1.0.228
> 294.9          Compiling target-lexicon v0.13.5
> 294.9          Compiling zerocopy v0.8.47
> 294.9          Compiling log v0.4.29
> 294.9          Compiling pin-project-lite v0.2.17
> 294.9          Compiling smallvec v1.15.1
> 294.9       error: linker `cc` not found
> 294.9         |
> 294.9         = note: No such file or directory (os error 2)
> 294.9       
> 294.9          Compiling crossbeam-utils v0.8.21
> 294.9       error: could not compile `proc-macro2` (build script) due to 1 previous error
> 294.9       warning: build failed, waiting for other jobs to finish...
> 294.9       error: could not compile `quote` (build script) due to 1 previous error
> 294.9       error: could not compile `serde_core` (build script) due to 1 previous error
> 294.9       error: could not compile `libm` (build script) due to 1 previous error
> 294.9       error: could not compile `serde` (build script) due to 1 previous error
> 294.9       error: could not compile `libc` (build script) due to 1 previous error
> 294.9       error: could not compile `zerocopy` (build script) due to 1 previous error
> 294.9       error: could not compile `target-lexicon` (build script) due to 1 previous error
> 294.9       error: could not compile `crossbeam-utils` (build script) due to 1 previous error
> 294.9       💥 maturin failed
> 294.9         Caused by: Failed to build a native library through cargo
> 294.9         Caused by: Cargo build finished with "exit status: 101": `env -u CARGO PYO3_BUILD_EXTENSION_MODULE="1" PYO3_ENVIRONMENT_SIGNATURE="cpython-3.12-64bit" PYO3_PYTHON="/usr/local/bin/python3.12" PYTHON_SYS_EXECUTABLE="/usr/local/bin/python3.12" "cargo" "rustc" "--profile" "release" "--message-format" "json-render-diagnostics" "--manifest-path" "/tmp/pip-install-et04sl9y/search-rdf_8102dc867e184092b54b3742e6288f83/Cargo.toml" "--lib" "--crate-type" "cdylib"`
> 294.9       Error: command ['maturin', 'pep517', 'build-wheel', '-i', '/usr/local/bin/python3.12', '--compatibility', 'off'] returned non-zero exit status 1
> 294.9       [end of output]
> 294.9   
> 294.9   note: This error originates from a subprocess, and is likely not a problem with pip.
> 294.9   ERROR: Failed building wheel for search-rdf
> 294.9 Successfully built grasp-rdf
> 294.9 Failed to build search-rdf
> 295.0 
> 295.0 [notice] A new release of pip is available: 25.0.1 -> 26.1.2
> 295.0 [notice] To update, run: pip install --upgrade pip
> 295.0 ERROR: Failed to build installable wheels for some pyproject.toml based projects (search-rdf)