### PR TITLE
Add API reverse proxy to webapp nginx config

### DIFF
--- a/apps/grasp/nginx.conf
+++ b/apps/grasp/nginx.conf
@@ -8,6 +8,28 @@ server {
     # Use relative redirects so they work behind a reverse proxy with a path prefix.
     absolute_redirect off;
 
+    # WebSocket upgrade for the GRASP /live endpoint.
+    location /api/live {
+        proxy_pass http://grasp:6789/live;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Proxy all other /api/* requests to the GRASP backend (strips /api prefix).
+    # e.g. GET /api/knowledge_graphs  →  http://grasp:6789/knowledge_graphs
+    location /api/ {
+        proxy_pass http://grasp:6789/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     # Static assets (checked first due to regex priority).
     location ~* \.(?:ico|gif|jpe?g|png|svg|webp|woff2?|ttf|eot|otf|js|css|map|json)$ {
         try_files $uri =404;


### PR DESCRIPTION
### Problem
When running the webapp and GRASP backend as separate containers, the Svelte app makes all API calls to `/api/*` (baked in at build time via `API_BASE=/api`). Without a proxy, nginx would attempt to serve those paths as static files and return 404 for every API call and WebSocket connection.

### Solution
Added two `location` blocks to `apps/grasp/nginx.conf`:

- **`location /api/`** — proxies HTTP API requests to the GRASP backend, stripping the `/api` prefix:
  `GET /api/knowledge_graphs` → `http://grasp:6789/knowledge_graphs`

- **`location /api/live`** — proxies the WebSocket streaming endpoint with the required `Upgrade`/`Connection` headers so nginx hands off the persistent connection rather than treating it as a plain HTTP request.

Both blocks forward `X-Real-IP`, `X-Forwarded-For`, and `X-Forwarded-Proto` so the backend sees correct client information.

### Result
The webapp container on port 80 is the single entry point. The browser never needs direct access to the GRASP backend port; nginx routes static files and API calls appropriately.